### PR TITLE
Potential security issue in src/google/protobuf/text_format.cc: Unchecked return from initialization function

### DIFF
--- a/src/google/protobuf/text_format.cc
+++ b/src/google/protobuf/text_format.cc
@@ -1334,7 +1334,7 @@ class TextFormat::Printer::TextGenerator
         memset(buffer_, ' ', buffer_size_);
       }
       size -= buffer_size_;
-      void* void_buffer;
+      void* void_buffer = nullptr;
       failed_ = !output_->Next(&void_buffer, &buffer_size_);
       if (failed_) return;
       buffer_ = reinterpret_cast<char*>(void_buffer);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src/google/protobuf/text_format.cc` 
Function: `Next@ZeroCopyOutputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/text_format.cc#L1338
Code extract:

```cpp
      }
      size -= buffer_size_;
      void* void_buffer;
      failed_ = !output_->Next(&void_buffer, &buffer_size_); <------ HERE
      if (failed_) return;
      buffer_ = reinterpret_cast<char*>(void_buffer);
```

