### PR TITLE
Potential security issue in src/google/protobuf/util/internal/protostream_objectsource.cc: Unchecked return from initialization function

### DIFF
--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -281,7 +281,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
   uint32 tag_to_return = 0;
   do {
     // Render map entry message type.
-    uint32 buffer32;
+    uint32 buffer32 = 0;
     stream_->ReadVarint32(&buffer32);  // message length
     int old_limit = stream_->PushLimit(buffer32);
     std::string map_key;
@@ -321,7 +321,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
 
 Status ProtoStreamObjectSource::RenderPacked(
     const google::protobuf::Field* field, ObjectWriter* ow) const {
-  uint32 length;
+  uint32 length = 0;
   stream_->ReadVarint32(&length);
   int old_limit = stream_->PushLimit(length);
   while (stream_->BytesUntilLimit() > 0) {
@@ -501,7 +501,7 @@ Status ProtoStreamObjectSource::RenderString(const ProtoStreamObjectSource* os,
                                              StringPiece field_name,
                                              ObjectWriter* ow) {
   uint32 tag = os->stream_->ReadTag();
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   std::string str;  // default value of empty for String wrapper
   if (tag != 0) {
     os->stream_->ReadVarint32(&buffer32);  // string size.
@@ -517,7 +517,7 @@ Status ProtoStreamObjectSource::RenderBytes(const ProtoStreamObjectSource* os,
                                             StringPiece field_name,
                                             ObjectWriter* ow) {
   uint32 tag = os->stream_->ReadTag();
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   std::string str;
   if (tag != 0) {
     os->stream_->ReadVarint32(&buffer32);
@@ -613,12 +613,12 @@ Status ProtoStreamObjectSource::RenderAny(const ProtoStreamObjectSource* os,
     // //google/protobuf/any.proto
     if (field->number() == 1) {
       // read type_url
-      uint32 type_url_size;
+      uint32 type_url_size = 0;
       os->stream_->ReadVarint32(&type_url_size);
       os->stream_->ReadString(&type_url, type_url_size);
     } else if (field->number() == 2) {
       // read value
-      uint32 value_size;
+      uint32 value_size = 0;
       os->stream_->ReadVarint32(&value_size);
       os->stream_->ReadString(&value, value_size);
     }
@@ -680,7 +680,7 @@ Status ProtoStreamObjectSource::RenderFieldMask(
     const ProtoStreamObjectSource* os, const google::protobuf::Type& type,
     StringPiece field_name, ObjectWriter* ow) {
   std::string combined;
-  uint32 buffer32;
+  uint32 buffer32 = 0;
   uint32 paths_field_tag = 0;
   for (uint32 tag = os->stream_->ReadTag(); tag != 0;
        tag = os->stream_->ReadTag()) {
@@ -770,7 +770,7 @@ Status ProtoStreamObjectSource::RenderField(
   // and ends up using a lot of stack space. Keep the stack usage of this
   // message small in order to preserve stack space and not crash.
   if (field->kind() == google::protobuf::Field::TYPE_MESSAGE) {
-    uint32 buffer32;
+    uint32 buffer32 = 0;
     stream_->ReadVarint32(&buffer32);  // message length
     int old_limit = stream_->PushLimit(buffer32);
     // Get the nested message type for this field.
@@ -810,8 +810,8 @@ Status ProtoStreamObjectSource::RenderNonMessageField(
     const google::protobuf::Field* field, StringPiece field_name,
     ObjectWriter* ow) const {
   // Temporary buffers of different types.
-  uint32 buffer32;
-  uint64 buffer64;
+  uint32 buffer32 = 0;
+  uint64 buffer64 = 0;
   std::string strbuffer;
   switch (field->kind()) {
     case google::protobuf::Field::TYPE_BOOL: {
@@ -939,85 +939,85 @@ const std::string ProtoStreamObjectSource::ReadFieldValueAsString(
   std::string result;
   switch (field.kind()) {
     case google::protobuf::Field::TYPE_BOOL: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = buffer64 != 0 ? "true" : "false";
       break;
     }
     case google::protobuf::Field::TYPE_INT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = StrCat(bit_cast<int32>(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_INT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = StrCat(bit_cast<int64>(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_UINT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = StrCat(bit_cast<uint32>(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_UINT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = StrCat(bit_cast<uint64>(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_SINT32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       result = StrCat(WireFormatLite::ZigZagDecode32(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_SINT64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadVarint64(&buffer64);
       result = StrCat(WireFormatLite::ZigZagDecode64(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_SFIXED32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = StrCat(bit_cast<int32>(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_SFIXED64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = StrCat(bit_cast<int64>(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_FIXED32: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = StrCat(bit_cast<uint32>(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_FIXED64: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = StrCat(bit_cast<uint64>(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_FLOAT: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadLittleEndian32(&buffer32);
       result = SimpleFtoa(bit_cast<float>(buffer32));
       break;
     }
     case google::protobuf::Field::TYPE_DOUBLE: {
-      uint64 buffer64;
+      uint64 buffer64 = 0;
       stream_->ReadLittleEndian64(&buffer64);
       result = SimpleDtoa(bit_cast<double>(buffer64));
       break;
     }
     case google::protobuf::Field::TYPE_ENUM: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);
       // Get the nested enum type for this field.
       // TODO(skarvaje): Avoid string manipulation. Find ways to speed this
@@ -1035,13 +1035,13 @@ const std::string ProtoStreamObjectSource::ReadFieldValueAsString(
       break;
     }
     case google::protobuf::Field::TYPE_STRING: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);  // string size.
       stream_->ReadString(&result, buffer32);
       break;
     }
     case google::protobuf::Field::TYPE_BYTES: {
-      uint32 buffer32;
+      uint32 buffer32 = 0;
       stream_->ReadVarint32(&buffer32);  // bytes size.
       stream_->ReadString(&result, buffer32);
       break;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

40 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L285
Code extract:

```cpp
  do {
    // Render map entry message type.
    uint32 buffer32;
    stream_->ReadVarint32(&buffer32);  // message length <------ HERE
    int old_limit = stream_->PushLimit(buffer32);
    std::string map_key;
```

---
**Instance 2**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L325
Code extract:

```cpp
Status ProtoStreamObjectSource::RenderPacked(
    const google::protobuf::Field* field, ObjectWriter* ow) const {
  uint32 length;
  stream_->ReadVarint32(&length); <------ HERE
  int old_limit = stream_->PushLimit(length);
  while (stream_->BytesUntilLimit() > 0) {
```

---
**Instance 3**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L507
Code extract:

```cpp
  uint32 buffer32;
  std::string str;  // default value of empty for String wrapper
  if (tag != 0) {
    os->stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
    os->stream_->ReadString(&str, buffer32);
    os->stream_->ReadTag();
```

---
**Instance 4**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L523
Code extract:

```cpp
  uint32 buffer32;
  std::string str;
  if (tag != 0) {
    os->stream_->ReadVarint32(&buffer32); <------ HERE
    os->stream_->ReadString(&str, buffer32);
    os->stream_->ReadTag();
```

---
**Instance 5**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L617
Code extract:

```cpp
    if (field->number() == 1) {
      // read type_url
      uint32 type_url_size;
      os->stream_->ReadVarint32(&type_url_size); <------ HERE
      os->stream_->ReadString(&type_url, type_url_size);
    } else if (field->number() == 2) {
```

---
**Instance 6**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L622
Code extract:

```cpp
    } else if (field->number() == 2) {
      // read value
      uint32 value_size;
      os->stream_->ReadVarint32(&value_size); <------ HERE
      os->stream_->ReadString(&value, value_size);
    }
```

---
**Instance 7**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L699
Code extract:

```cpp
                          "Invalid FieldMask, unexpected field.");
    }
    std::string str;
    os->stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
    os->stream_->ReadString(&str, buffer32);
    if (!combined.empty()) {
```

---
**Instance 8**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L774
Code extract:

```cpp
  // message small in order to preserve stack space and not crash.
  if (field->kind() == google::protobuf::Field::TYPE_MESSAGE) {
    uint32 buffer32;
    stream_->ReadVarint32(&buffer32);  // message length <------ HERE
    int old_limit = stream_->PushLimit(buffer32);
    // Get the nested message type for this field.
```

---
**Instance 9**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L818
Code extract:

```cpp
  std::string strbuffer;
  switch (field->kind()) {
    case google::protobuf::Field::TYPE_BOOL: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderBool(field_name, buffer64 != 0);
      break;
```

---
**Instance 10**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L823
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_INT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, bit_cast<int32>(buffer32));
      break;
```

---
**Instance 11**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L828
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_INT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, bit_cast<int64>(buffer64));
      break;
```

---
**Instance 12**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L833
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_UINT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderUint32(field_name, bit_cast<uint32>(buffer32));
      break;
```

---
**Instance 13**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L838
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_UINT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderUint64(field_name, bit_cast<uint64>(buffer64));
      break;
```

---
**Instance 14**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L843
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_SINT32: {
      stream_->ReadVarint32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, WireFormatLite::ZigZagDecode32(buffer32));
      break;
```

---
**Instance 15**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L848
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_SINT64: {
      stream_->ReadVarint64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, WireFormatLite::ZigZagDecode64(buffer64));
      break;
```

---
**Instance 16**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L853
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_SFIXED32: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderInt32(field_name, bit_cast<int32>(buffer32));
      break;
```

---
**Instance 17**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L858
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_SFIXED64: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderInt64(field_name, bit_cast<int64>(buffer64));
      break;
```

---
**Instance 18**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L863
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_FIXED32: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderUint32(field_name, bit_cast<uint32>(buffer32));
      break;
```

---
**Instance 19**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L868
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_FIXED64: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderUint64(field_name, bit_cast<uint64>(buffer64));
      break;
```

---
**Instance 20**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L873
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_FLOAT: {
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      ow->RenderFloat(field_name, bit_cast<float>(buffer32));
      break;
```

---
**Instance 21**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L878
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_DOUBLE: {
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      ow->RenderDouble(field_name, bit_cast<double>(buffer64));
      break;
```

---
**Instance 22**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L883
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_ENUM: {
      stream_->ReadVarint32(&buffer32); <------ HERE

      // If the field represents an explicit NULL value, render null.
```

---
**Instance 23**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L919
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_STRING: {
      stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
      stream_->ReadString(&strbuffer, buffer32);
      ow->RenderString(field_name, strbuffer);
```

---
**Instance 24**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L925
Code extract:

```cpp
      break;
    }
    case google::protobuf::Field::TYPE_BYTES: {
      stream_->ReadVarint32(&buffer32);  // bytes size. <------ HERE
      stream_->ReadString(&strbuffer, buffer32);
      ow->RenderBytes(field_name, strbuffer);
```

---
**Instance 25**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L943
Code extract:

```cpp
  switch (field.kind()) {
    case google::protobuf::Field::TYPE_BOOL: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = buffer64 != 0 ? "true" : "false";
      break;
```

---
**Instance 26**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L949
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_INT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = StrCat(bit_cast<int32>(buffer32));
      break;
```

---
**Instance 27**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L955
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_INT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = StrCat(bit_cast<int64>(buffer64));
      break;
```

---
**Instance 28**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L961
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_UINT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = StrCat(bit_cast<uint32>(buffer32));
      break;
```

---
**Instance 29**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L967
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_UINT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = StrCat(bit_cast<uint64>(buffer64));
      break;
```

---
**Instance 30**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L973
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_SINT32: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      result = StrCat(WireFormatLite::ZigZagDecode32(buffer32));
      break;
```

---
**Instance 31**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L979
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_SINT64: {
      uint64 buffer64;
      stream_->ReadVarint64(&buffer64); <------ HERE
      result = StrCat(WireFormatLite::ZigZagDecode64(buffer64));
      break;
```

---
**Instance 32**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L985
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_SFIXED32: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = StrCat(bit_cast<int32>(buffer32));
      break;
```

---
**Instance 33**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L991
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_SFIXED64: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = StrCat(bit_cast<int64>(buffer64));
      break;
```

---
**Instance 34**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L997
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_FIXED32: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = StrCat(bit_cast<uint32>(buffer32));
      break;
```

---
**Instance 35**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1003
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_FIXED64: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = StrCat(bit_cast<uint64>(buffer64));
      break;
```

---
**Instance 36**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1009
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_FLOAT: {
      uint32 buffer32;
      stream_->ReadLittleEndian32(&buffer32); <------ HERE
      result = SimpleFtoa(bit_cast<float>(buffer32));
      break;
```

---
**Instance 37**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadLittleEndian64@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1015
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_DOUBLE: {
      uint64 buffer64;
      stream_->ReadLittleEndian64(&buffer64); <------ HERE
      result = SimpleDtoa(bit_cast<double>(buffer64));
      break;
```

---
**Instance 38**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1021
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_ENUM: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32); <------ HERE
      // Get the nested enum type for this field.
      // TODO(skarvaje): Avoid string manipulation. Find ways to speed this
```

---
**Instance 39**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1039
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_STRING: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32);  // string size. <------ HERE
      stream_->ReadString(&result, buffer32);
      break;
```

---
**Instance 40**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Function: `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/561c9cd592a3265334fadf23d0a4af7ac96e1205/src/google/protobuf/util/internal/protostream_objectsource.cc#L1045
Code extract:

```cpp
    }
    case google::protobuf::Field::TYPE_BYTES: {
      uint32 buffer32;
      stream_->ReadVarint32(&buffer32);  // bytes size. <------ HERE
      stream_->ReadString(&result, buffer32);
      break;
```

