### PR TITLE
Potential issue in src/google/protobuf/util/internal/protostream_objectsource.cc: Unchecked return from initialization function

### DIFF
--- a/src/google/protobuf/util/internal/protostream_objectsource.cc
+++ b/src/google/protobuf/util/internal/protostream_objectsource.cc
@@ -281,7 +281,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
   uint32 tag_to_return = 0;
   do {
     // Render map entry message type.
-    uint32 buffer32;
+    uint32 buffer32 = 0;
     stream_->ReadVarint32(&buffer32);  // message length
     int old_limit = stream_->PushLimit(buffer32);
     std::string map_key;
@@ -321,7 +321,7 @@ StatusOr<uint32> ProtoStreamObjectSource::RenderMap(
 
 Status ProtoStreamObjectSource::RenderPacked(
     const google::protobuf::Field* field, ObjectWriter* ow) const {
-  uint32 length;
+  uint32 length = 0;
   stream_->ReadVarint32(&length);
   int old_limit = stream_->PushLimit(length);
   while (stream_->BytesUntilLimit() > 0) {


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `src/google/protobuf/util/internal/protostream_objectsource.cc` 
Enclosing Function : `RenderPacked@ProtoStreamObjectSource@converter@util@protobuf@google`
Function : `ReadVarint32@CodedInputStream@io@protobuf@google` 
https://github.com/siva-msft/protobuf/blob/3a3b80d80438ff0bf9e1b4a8f944f2a02edb6262/src/google/protobuf/util/internal/protostream_objectsource.cc#L325
**Issue in**: _length_

**Code extract**:

```cpp
Status ProtoStreamObjectSource::RenderPacked(
    const google::protobuf::Field* field, ObjectWriter* ow) const {
  uint32 length;
  stream_->ReadVarint32(&length); <------ HERE
  int old_limit = stream_->PushLimit(length);
  while (stream_->BytesUntilLimit() > 0) {
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
